### PR TITLE
Add `typing_extensions` to install requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
         'nano-CAT@git+https://github.com/nlesc-nano/nano-CAT@master',
         'data-CAT@git+https://github.com/nlesc-nano/data-CAT@master',
         'mendeleev', 'more_itertools', 'numpy', 'pandas',
-        'pyyaml>=5.1.1', 'schema'],
+        'pyyaml>=5.1.1', 'schema', 'typing_extensions'],
     entry_points={
         'console_scripts': [
             'smiles_screener=flamingo.screen:main',


### PR DESCRIPTION
This PR formally adds `typing_extensions` as a `flamingo` dependency.

Previously flamingo was depdendant on acquiring  `typing_extensions` via `CAT`, 
but CAT does not require typing_extensions for python >= 3.8 which can lead to some importerrors.