### PR TITLE
Add `__init__.py` to the `models` sub-module

### DIFF
--- a/flamingo/models/__init__.py
+++ b/flamingo/models/__init__.py
@@ -1,0 +1,5 @@
+"""The :mod:`models` sub-module."""
+
+from .scscore import SCScorer
+
+__all__ = ["SCScorer"]


### PR DESCRIPTION
Turns out `__init__.py` was missing.