### PR TITLE
TST: Move out of the current working directory before running tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,8 @@ jobs:
       env:
         CONDA_PREFIX: /usr/share/miniconda
       run: |
-        pytest
+        cd ..
+        pytest flamingo/flamingo flamingo/tests
 
     - name: coverage
       uses: codecov/codecov-action@v1


### PR DESCRIPTION
In principle this test should fail prior to the merging https://github.com/nlesc-nano/flamingo/pull/12 as the `flamingo/data` directory is not included in the build, only in the current working directory.