### PR TITLE
Reintroduced retry to fix PLAMS file issue

### DIFF
--- a/flamingo/cat_interface.py
+++ b/flamingo/cat_interface.py
@@ -20,6 +20,7 @@ import yaml
 from CAT.base import prep
 from dataCAT import prop_to_dataframe
 from more_itertools import chunked
+from retry import retry
 from scm.plams import Settings
 
 from .utils import Options, normalize_smiles
@@ -46,6 +47,7 @@ class PropertyMetadata(NamedTuple):
     dset: str  # Dset in the HDF5
 
 
+@retry(FileExistsError, delay=1, tries=100)
 def call_cat(smiles: pd.Series, opts: Mapping[str, Any], cat_properties: Dict[str, Any],
              chunk_name: str = "0") -> Path:
     """Call cat with a given `config` and returns a dataframe with the results.

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
         'nano-CAT@git+https://github.com/nlesc-nano/nano-CAT@master',
         'data-CAT@git+https://github.com/nlesc-nano/data-CAT@master',
         'mendeleev', 'more_itertools', 'numpy', 'pandas',
-        'pyyaml>=5.1.1', 'schema', 'typing_extensions'],
+        'pyyaml>=5.1.1', 'retry', 'schema', 'typing_extensions'],
     entry_points={
         'console_scripts': [
             'smiles_screener=flamingo.screen:main',


### PR DESCRIPTION
## Description
[Plams](https://github.com/SCM-NV/PLAMS) Uses global variables to store folders names. When running with multiple processes it causes a race condition

## Naive Solution
Retry until the race condition disappears
