### PR TITLE
Control the number of CPU cores to use

### DIFF
--- a/flamingo/cat_interface.py
+++ b/flamingo/cat_interface.py
@@ -211,8 +211,8 @@ def map_reduce(smiles: pd.Series, opts: Options,
     """Distribute the properties computation in batches."""
     worker = partial(callback, smiles, opts.to_dict())
 
-    with Pool() as p:
-        results = p.map(worker, chunked(smiles.index, 10))
+    with Pool(opts.nthreads) as p:
+        results = list(p.imap(worker, chunked(smiles.index, 10), opts.batch_size))
 
     return reduce(results)
 

--- a/flamingo/schemas.py
+++ b/flamingo/schemas.py
@@ -19,7 +19,7 @@ from .utils import Options
 
 # Number of Cores to use
 CORES = cpu_count()
-THREADS =  CORES / 2 if CORES > 1 else 1
+THREADS =  CORES // 2 if CORES > 1 else 1
 
 #: Schema to validate the ordering keywords
 SCHEMA_ORDERING = Or(

--- a/flamingo/schemas.py
+++ b/flamingo/schemas.py
@@ -8,13 +8,18 @@
     :annotation: : schema.Schema
 
 """
-from numbers import Real
 import tempfile
-from schema import Optional, Or, Schema, SchemaError
+from multiprocessing import cpu_count
+from numbers import Real
 
 import yaml
+from schema import Optional, Or, Schema, SchemaError
 
 from .utils import Options
+
+# Number of Cores to use
+CORES = cpu_count()
+THREADS =  CORES / 2 if CORES > 1 else 1
 
 #: Schema to validate the ordering keywords
 SCHEMA_ORDERING = Or(
@@ -61,7 +66,10 @@ SCHEMA_SCREEN = Schema({
     Optional("batch_size", default=1000): int,
 
     # File to print the final candidates
-    Optional("output_path", default="results"): str
+    Optional("output_path", default="results"): str,
+
+    # Number of Cpus cores to use
+    Optional("nthreads", default=THREADS): int
 })
 
 DICT_ACTIONS = {"screen": SCHEMA_SCREEN}


### PR DESCRIPTION
## Changes
* Introduce the `nthreads` keyword to set the number of CPU cores to use.

Avoid using all the CPUs when there is too much booking that is ruining the parallelism