### PR TITLE
used chunksize of 1 for the pool distributing CAT

### DIFF
--- a/flamingo/cat_interface.py
+++ b/flamingo/cat_interface.py
@@ -215,7 +215,7 @@ def map_reduce(smiles: pd.Series, opts: Options,
     worker = partial(callback, smiles, opts.to_dict())
 
     with Pool() as p:
-        results = list(p.imap_unordered(worker, chunked(smiles.index, 10), 10))
+        results = list(p.imap_unordered(worker, chunked(smiles.index, 10), 1))
 
     return reduce(results)
 


### PR DESCRIPTION
## Changes
* Use all the available cpu by settings `chunksize = 1` for [imap_unordered](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.pool.Pool.imap_unordered) method